### PR TITLE
[Fix] 장소 추천 boardType 파라미터 값 수정

### DIFF
--- a/src/pages/PostListPage.tsx
+++ b/src/pages/PostListPage.tsx
@@ -14,7 +14,7 @@ type BoardType = (typeof BOARD_TYPES)[number]
 const BOARD_TYPE_PARAM_MAP: Record<BoardType, string> = {
   '자유 게시판': 'FREE',
   '일정 공유': 'PLAN_SHARE',
-  '장소 추천': 'PLACE_RECOMMENDATION',
+  '장소 추천': 'PLACE_RECOMMEND',
 }
 
 const BOARD_TYPE_LABEL_BY_PARAM = (


### PR DESCRIPTION
## 수정 내용
- 장소 추천 boardType 파라미터를 PLACE_RECOMMEND로 변경
- 기존 400 오류 발생 원인 제거

## 확인 사항
- 장소 추천 게시판 조회 정상 동작 여부