### PR TITLE
[Feat]게시글 상세 화면 설계서 기준 UI 및 기능 개선

### DIFF
--- a/src/api/posts.ts
+++ b/src/api/posts.ts
@@ -63,6 +63,9 @@ export interface PostDetail {
   planThumbnailImageUrl?: string | null
   rating?: number | null
   googlePlaceId?: string | null
+  tripId?: number | null
+  tripTitle?: string | null
+  planThumbnailUrl?: string | null
 }
 
 export interface CommentItem {

--- a/src/assets/plan-default.svg
+++ b/src/assets/plan-default.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800" height="600" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#FDF6EA"/>
+      <stop offset="100%" stop-color="#FFF2D8"/>
+    </linearGradient>
+    <linearGradient id="pinGlow" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#F5B636"/>
+      <stop offset="100%" stop-color="#E19F1E"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" rx="40" fill="url(#bgGradient)" stroke="#F4D29B" stroke-width="4"/>
+  <g transform="translate(400, 270)">
+    <path
+      d="M0,-80c26,0 47,21 47,47s-47,110-47,110-47-70-47-110 21-47 47-47Z"
+      fill="url(#pinGlow)"
+    />
+    <circle cx="0" cy="-23" r="36" fill="#fff"/>
+    <circle cx="0" cy="-23" r="14" fill="#E19F1E"/>
+  </g>
+  <text x="50%" y="68%" text-anchor="middle" font-size="72" font-weight="800" letter-spacing="16" font-family="Pretendard, Noto Sans KR, Arial, sans-serif" fill="#1C1C1C">
+    PLANIT
+  </text>
+</svg>

--- a/src/constants/plan.ts
+++ b/src/constants/plan.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_PLAN_THUMBNAIL_URL = new URL('../assets/plan-default.svg', import.meta.url).href

--- a/src/pages/PostDetailPage.tsx
+++ b/src/pages/PostDetailPage.tsx
@@ -9,6 +9,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import Modal from '../components/Modal'
 import Toast from '../components/Toast'
 import { DEFAULT_AVATAR_URL } from '../constants/avatar'
+import { DEFAULT_PLAN_THUMBNAIL_URL } from '../constants/plan'
 import { resolveImageUrl } from '../utils/image.ts'
 import {
   createComment,
@@ -302,12 +303,10 @@ export default function PostDetailPage() {
   }
 
   const handlePlanCardClick = () => {
-    if (!detail?.planId) {
+  if (!detail?.tripId) {
       return
     }
-    navigate(`/trips/${detail.planId}/itineraries`, {
-      state: { readonly: true },
-    })
+    navigate(`/trips/${detail.tripId}/itineraries?readonly=true`)
   }
 
   const handleCloseLightbox = () => {
@@ -351,11 +350,6 @@ export default function PostDetailPage() {
   useEffect(() => {
     detailRef.current = detail
   }, [detail])
-
-  const planPeriodLabel =
-    detail?.planStartDate && detail?.planEndDate
-      ? `${detail.planStartDate} ~ ${detail.planEndDate}`
-      : detail?.planStartDate || detail?.planEndDate || ''
 
   const totalCommentCount = detail?.commentCount ?? 0
   const isAuthor = detail?.author.authorId === user?.id
@@ -438,7 +432,7 @@ export default function PostDetailPage() {
                 </div>
               )}
             </header>
-            {detail.boardType === 'PLAN_SHARE' && detail.planId && (
+            {detail.tripId && (
               <button
                 type="button"
                 className="plan-share-card"
@@ -448,27 +442,26 @@ export default function PostDetailPage() {
                 <div className="plan-share-card__image">
                   <img
                     src={
-                      resolveImageUrl(
-                        detail.planThumbnailImageUrl ||
-                          detail.images?.find((item) => item.url)?.url,
-                        DEFAULT_AVATAR_URL,
-                      )
+                      detail.planThumbnailUrl
+                        ? resolveImageUrl(detail.planThumbnailUrl, DEFAULT_PLAN_THUMBNAIL_URL)
+                        : DEFAULT_PLAN_THUMBNAIL_URL
                     }
-                    alt={detail.planTitle ? `${detail.planTitle} 썸네일` : '공유된 일정 이미지'}
+                    alt={detail.tripTitle ? `${detail.tripTitle} 썸네일` : '공유된 일정 이미지'}
+                    onError={(event) => {
+                      const target = event.currentTarget
+                      target.onerror = null
+                      target.src = DEFAULT_PLAN_THUMBNAIL_URL
+                    }}
                   />
                 </div>
                 <div className="plan-share-card__body">
                   <p className="plan-share-card__label">공유된 일정</p>
-                  <h2>{detail.planTitle || '공유된 일정'}</h2>
-                  {planPeriodLabel && (
-                    <p className="plan-share-card__period">{planPeriodLabel}</p>
-                  )}
-                  <p className="plan-share-card__hint">일정 재생성 및 채팅은 비활성화</p>
+                  <h2>{detail.tripTitle || '공유된 일정'}</h2>
+                  <p className="plan-share-card__hint">일정 재생성과 채팅은 비활성화</p>
                 </div>
                 <div className="plan-share-card__cta">일정 결과 보기</div>
               </button>
-            )}
-            {detail.images && detail.images.filter((img) => img.url).length > 0 && (
+            )}            {detail.images && detail.images.filter((img) => img.url).length > 0 && (
               <div className="post-detail-images">
                 {detail.images
                   .filter((img) => img.url)

--- a/src/pages/TripCreatePage.tsx
+++ b/src/pages/TripCreatePage.tsx
@@ -191,7 +191,8 @@ export default function TripCreatePage() {
   const routeTripId = Number(params.tripId)
   const locationState = (location.state as TripRouteState | null) ?? null
   const stateTripId = Number(locationState?.tripId)
-  const isReadonlyTripView = Boolean(locationState?.readonly)
+  const queryReadonly = new URLSearchParams(location.search).get('readonly') === 'true'
+  const isReadonlyTripView = queryReadonly || Boolean(locationState?.readonly)
   const currentTripId = Number.isFinite(routeTripId) && routeTripId > 0
     ? routeTripId
     : Number.isFinite(stateTripId) && stateTripId > 0
@@ -493,7 +494,7 @@ export default function TripCreatePage() {
                 <>
                   <button
                     className="pill-button"
-                    disabled={!currentTripId || tripData?.isOwner === false}
+                    disabled={!currentTripId || (!isReadonlyTripView && tripData?.isOwner === false)}
                     onClick={async () => {
                       if (!currentTripId) return
                       try {
@@ -510,7 +511,7 @@ export default function TripCreatePage() {
                   </button>
                   <button
                     className="pill-button"
-                    disabled={tripData?.isOwner === false}
+                    disabled={!isReadonlyTripView && tripData?.isOwner === false}
                     onClick={async () => {
                       if (!showEditMode) {
                         const drafts: Record<number, ActivityDraft> = {}


### PR DESCRIPTION
## 작업 내용

- 일정 공유 게시글 상세 화면을 화면설계서 기준으로 정리
- 게시글 상단에 선택된 일정 카드 노출
- 일정 카드 클릭 시 일정 결과 페이지로 이동하도록 연결
- 좋아요 버튼 상태 및 UI 정리
- 댓글 입력 영역 UX 개선
- 작성자에게만 수정/삭제 버튼 노출 처리

## 변경 범위

- PostDetailPage 중심 프론트 UI 수정
- 기존 도메인 로직은 최대한 유지

## 확인 사항

- 일정 공유 게시글에서 일정 카드 정상 노출 여부
- 좋아요 토글 정상 동작 여부
- 댓글 등록 및 조회 정상 동작 여부
